### PR TITLE
Updated Opus version + iOS version

### DIFF
--- a/build-libopus.sh
+++ b/build-libopus.sh
@@ -22,9 +22,9 @@
 ###########################################################################
 #  Choose your libopus version and your currently-installed iOS SDK version:
 #
-VERSION="1.1"
-SDKVERSION="7.0"
-MINIOSVERSION="6.0"
+VERSION="1.1.2"
+SDKVERSION="9.2"
+MINIOSVERSION="8.0"
 
 ###########################################################################
 #


### PR DESCRIPTION
Just updated the iOS version to `9.2` (and min version to `8.0`).
Also updated opus codec version from `1.1` to `1.1.2` to be able to use the newest improvements.