### PR TITLE
Updated libopus to 1.1.3, fixed cross-compile error under Xcode 8

### DIFF
--- a/build-libopus.sh
+++ b/build-libopus.sh
@@ -22,8 +22,8 @@
 ###########################################################################
 #  Choose your libopus version and your currently-installed iOS SDK version:
 #
-VERSION="1.1.2"
-SDKVERSION="9.2"
+VERSION="1.1.3"
+SDKVERSION="10.2"
 MINIOSVERSION="8.0"
 
 ###########################################################################
@@ -104,7 +104,7 @@ do
     if [ "${ARCH}" == "i386" ] || [ "${ARCH}" == "x86_64" ]; then
         PLATFORM="iPhoneSimulator"
         EXTRA_CFLAGS="-arch ${ARCH}"
-        EXTRA_CONFIG=""
+        EXTRA_CONFIG="--host=x86_64-apple-darwin"
     else
         PLATFORM="iPhoneOS"
         EXTRA_CFLAGS="-arch ${ARCH}"


### PR DESCRIPTION
Using Xcode 8 if you run the script as-is you get the following error in `config.log`:

```
configure:3702: gcc -o conftest  -arch i386 -Ofast -flto -g -fPIE -miphoneos-version-min=\
8.0 -I/Users/bryan/Documents/OpusKit/Submodules/Opus-iOS/dependencies/include -isysroot /\
Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SD\
Ks/iPhoneSimulator10.2.sdk   -flto -fPIE -miphoneos-version-min=8.0 -L/Users/bryan/Docume\
nts/OpusKit/Submodules/Opus-iOS/dependencies/lib conftest.c  >&5
configure:3706: $? = 0
configure:3713: ./conftest
dyld: mach-o, but built for simulator (not macOS)
./configure: line 3715: 98125 Abort trap: 6           ./conftest$ac_cv_exeext
configure:3717: $? = 134
configure:3724: error: in `/Users/bryan/Documents/OpusKit/Submodules/Opus-iOS/build/src/o\
pus-1.1.3':
configure:3726: error: cannot run C compiled programs.
If you meant to cross compile, use `--host'.
```

This PR fixes this by adding EXTRA_CONFIG="--host=x86_64-apple-darwin".
